### PR TITLE
Prevent zombies from fleeing

### DIFF
--- a/Mod/Zombies/Defs/FactionDefs/Factions.xml
+++ b/Mod/Zombies/Defs/FactionDefs/Factions.xml
@@ -10,7 +10,7 @@
     <requiredCountAtGameStart>1</requiredCountAtGameStart>
     <canMakeRandomly>false</canMakeRandomly>
 	<hidden>true</hidden>
-	<!--canFlee>false</canFlee-->
+	<autoFlee>false</autoFlee>
     <raidCommonality>0</raidCommonality>
     <canSiege>false</canSiege>
     <canStageAttacks>false</canStageAttacks>


### PR DESCRIPTION
First of all, thanks for updating. It's working almost completely on A16. 
Although there are some small problems, I think it's worth uploading to steam workshop.

This small commit prevents the message "Zombies from ... are fleeing" on when half of the zombie raiders downed.

Thanks.